### PR TITLE
remove dataset_id 

### DIFF
--- a/doc/ch02-md-elements-data_center.adoc
+++ b/doc/ch02-md-elements-data_center.adoc
@@ -17,9 +17,10 @@ dataset. The element has the following child elements:
 
 * data_center_name: The name of the data center split into two child elements; short_name and long_name.
 * data_center_url: URL to the data center's main website.
-* dataset_id: The id assigned to the dataset by the data center. This may be different from metadata_identifier.
 
 Information on the data centre contact person for a data centre is conveyed through the element <<personnel>>. See <<personnel>> for more information. The role of a data center contact must be “Data center contact”.
+
+If an id is assigned to the dataset by the data center, it can be included as <<alternate_identifier>>.
 
 |Example XML a|
 ----
@@ -31,7 +32,6 @@ Information on the data centre contact person for a data centre is conveyed thro
          </long_name>
      </data_center_name>
      <data_center_url>http://met.no</data_center_url>
-     <dataset_id>45dlkf-234-df</dataset_id>
 </data_center>
 ----
 

--- a/input-examples/foo.mmd
+++ b/input-examples/foo.mmd
@@ -21,7 +21,6 @@
 			</long_name>
 		</data_center_name>
 		<data_center_url>http://met.no</data_center_url>
-		<dataset_id>hmmm?</dataset_id>
 		<contact>
 			<role>DATA CENTER CONTACT</role>
 			<name>Kristin Lyng</name>

--- a/xsd/mmd.xsd
+++ b/xsd/mmd.xsd
@@ -267,7 +267,6 @@
         <xs:sequence>
             <xs:element name="data_center_name" type="mmd:data_center_name_type" maxOccurs="1" minOccurs="1"></xs:element>
             <xs:element name="data_center_url" type="xs:string" maxOccurs="1" minOccurs="0"></xs:element>
-            <xs:element name="dataset_id" type="xs:string" maxOccurs="1" minOccurs="0"></xs:element>
             <xs:element name="contact" type="mmd:personnel_type"  maxOccurs="1" minOccurs="0"></xs:element>
         </xs:sequence>
     </xs:complexType>

--- a/xsd/solr-mmd-l1.xml
+++ b/xsd/solr-mmd-l1.xml
@@ -873,8 +873,6 @@
 
   <field name="mmd_data_center_data_center_url" type="text_en" indexed="true" stored="true" required="false" multiValued="false"/>
 
-  <field name="mmd_data_center_dataset_id" type="text_en" indexed="true" stored="true" required="false" multiValued="false"/>
-
   <field name="mmd_data_center_contact_role" type="text_en" indexed="true" stored="true" required="false" multiValued="false"/>
 
   <field name="mmd_data_center_contact_name" type="text_en" indexed="true" stored="true" required="false" multiValued="false"/>

--- a/xsd/solr-mmd-l2.xml
+++ b/xsd/solr-mmd-l2.xml
@@ -873,8 +873,6 @@
 
   <field name="mmd_data_center_data_center_url" type="text_en" indexed="true" stored="true" required="false" multiValued="false"/>
 
-  <field name="mmd_data_center_dataset_id" type="text_en" indexed="true" stored="true" required="false" multiValued="false"/>
-
   <field name="mmd_data_center_contact_role" type="text_en" indexed="true" stored="true" required="false" multiValued="false"/>
 
   <field name="mmd_data_center_contact_name" type="text_en" indexed="true" stored="true" required="false" multiValued="false"/>

--- a/xslt/dif-to-mmd.xsl
+++ b/xslt/dif-to-mmd.xsl
@@ -338,9 +338,10 @@ Meaning this should consume both DIF 8, 9 and 10.
                 <xsl:element name="mmd:data_center_url">
                     <xsl:value-of select="dif:Data_Center_URL" />
                 </xsl:element>
+		<!--TODO: Fix when alternate_identifier has been defined
                 <xsl:element name="mmd:dataset_id">
                     <xsl:value-of select="dif:Data_Set_ID" />
-                </xsl:element>
+                </xsl:element-->
                 <!-- removed 2020-03-25
                 <xsl:element name="mmd:contact">
                   <xsl:element name="mmd:role">

--- a/xslt/mmd-to-dif.xsl
+++ b/xslt/mmd-to-dif.xsl
@@ -310,9 +310,10 @@
                 <xsl:element name="dif:Data_Center_URL">
                     <xsl:value-of select="mmd:data_center_url" />
                 </xsl:element>
+		<!-- TODO: Fix when alternate_identifier has been defined
                 <xsl:element name="dif:Data_Set_ID">
                     <xsl:value-of select="mmd:dataset_id" />
-                </xsl:element>
+                </xsl:element-->
                 <xsl:choose>
                     <xsl:when test="mmd:personnel[mmd:role='Data center contact']">
                         <xsl:element name="dif:Personnel">

--- a/xslt/mmd-to-dif10.xsl
+++ b/xslt/mmd-to-dif10.xsl
@@ -192,9 +192,10 @@
 			<xsl:element name="dif:Data_Center_URL">
 				<xsl:value-of select="mmd:data_center_url" />
 			</xsl:element>
+			<!--TODO: Fix when alternate_identifier has been defined
 			<xsl:element name="dif:Data_Set_ID">
 				<xsl:value-of select="mmd:dataset_id" />
-			</xsl:element>
+			</xsl:element-->
 			<xsl:element name="dif:Personel">
 				<xsl:element name="dif:Role">
 					<xsl:value-of select="mmd:personnel/mmd:role"></xsl:value-of>


### PR DESCRIPTION
remove dataset_id: in documentation, mmd input example, mmd schema and solr schema. Commented out in the xlst dif files, as it should be updated when alternated_identifier has been defined (marked as TODO). 
This relates to #16. 